### PR TITLE
capture exceptions when listing binaries

### DIFF
--- a/scipion/install/install-plugin.py
+++ b/scipion/install/install-plugin.py
@@ -32,6 +32,7 @@ from future.utils import iteritems
 
 from plugin_funcs import PluginRepository, PluginInfo
 import script
+from pyworkflow.utils import redStr 
 
 #  ************************************************************************
 #  *                                                                      *
@@ -176,7 +177,11 @@ if parsedArgs.help or (mode in [MODE_INSTALL_BINS, MODE_UNINSTALL_BINS]
         env.setDefault(False)
         installedPlugins = Config.getDomain().getPlugins()
         for p, pobj in iteritems(installedPlugins):
-            pobj.Plugin.defineBinaries(env)
+            try:
+                pobj.Plugin.defineBinaries(env)
+            except Exception as e:
+                print(
+                    redStr("Error retrieving plugin %s binaries: "% str(p)), e )
         parserUsed.epilog += env.printHelp()
     parserUsed.print_help()
     parserUsed.exit(0)

--- a/scipion/install/plugin_funcs.py
+++ b/scipion/install/plugin_funcs.py
@@ -8,6 +8,7 @@ from pkg_resources import parse_version
 
 from funcs import Environment
 from pwem import Domain
+from pyworkflow.utils import redStr
 from pyworkflow.utils.path import cleanPath
 from pyworkflow import LAST_VERSION, CORE_VERSION, OLD_VERSIONS, Config
 from importlib import reload
@@ -324,7 +325,11 @@ class PluginInfo(object):
         defaultTargets = [target.getName() for target in env.getTargetList()]
         plugin = self.getPluginClass()
         if plugin is not None:
-            plugin.defineBinaries(env)
+            try:
+                plugin.defineBinaries(env)
+            except Exception as e:
+                print(
+                    redStr("Error retrieving plugin %s binaries: "% plugin.name), e )
         binVersions = [target.getName() for target in env.getTargetList() if target.getName() not in defaultTargets]
         return binVersions
 
@@ -396,7 +401,7 @@ class PluginRepository(object):
     def getBinToPluginDict():
         localPlugins = Domain.getPlugins()
         binToPluginDict = {}
-        for p, pobj in localPlugins.iteritems():
+        for p, pobj in localPlugins.items():
             pinfo = PluginInfo(name=p, plugin=pobj, remote=False)
             pbins = pinfo.getBinVersions()
             binToPluginDict.update({k: p for k in pbins})


### PR DESCRIPTION
We were executing the command

   scipion installb maxit

which needs to get a list of all  binaries that can be installed before performing the installation.
Unfortunately, a package (which starts by x) raised an exception and the installation stopped.

This modification captures the exception and prints an error message instead of stopping the whole process. We just added the following lines

+            try:
+                plugin.defineBinaries(env)
+            except Exception as e:
+                print( redStr("Error retrieving plugin %s binaries: "% plugin.name))

