### PR TITLE
JJ template desciption read

### DIFF
--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -163,7 +163,6 @@ class KickoffView(tk.Frame):
 
     def _closeCallback(self):
         self.root.destroy()
-        import sys
         sys.exit()
 
     def _fillContent(self, frame):

--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -153,13 +153,18 @@ class KickoffView(tk.Frame):
         # Add the Import project button
         btn = Button(btnFrame, Message.LABEL_BUTTON_CANCEL,
                      font=self.bigFontBold,
-                     command=self.windows.close)
+                     command=self._closeCallback)
         btn.grid(row=0, column=0, sticky='ne', pady=10)
 
         btnFrame.columnconfigure(0, weight=1)
         btnFrame.grid(row=1, column=0, sticky='news')
 
         self.columnconfigure(0, weight=1)
+
+    def _closeCallback(self):
+        self.root.destroy()
+        import sys
+        sys.exit()
 
     def _fillContent(self, frame):
         # Add project name

--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -88,7 +88,7 @@ class BoxWizardWindow(ProjectBaseWindow):
         settings = ProjectSettings()
         self.generalCfg = settings.getConfig()
 
-        ProjectBaseWindow.__init__(self, title, minsize=(650, 500), **kwargs)
+        ProjectBaseWindow.__init__(self, title, minsize=(800, 350), **kwargs)
         self.viewFuncs = {VIEW_WIZARD: BoxWizardView}
         self.switchView(VIEW_WIZARD, **kwargs)
 
@@ -126,23 +126,11 @@ class BoxWizardView(tk.Frame):
         self.projDateFont = tkFont.Font(size=smallSize, family=fontName)
         self.projDelFont = tkFont.Font(size=smallSize, family=fontName,
                                        weight='bold')
-        # Header section
-        headerFrame = tk.Frame(self, bg='white')
-        headerFrame.columnconfigure(0, weight=1)
-        headerFrame.grid(row=0, column=0, sticky='news')
-        headerText = "Enter your desired values"
-
-        label = tk.Label(headerFrame, text=headerText,
-                         font=self.bigFontBold,
-                         borderwidth=0, anchor='nw', bg='white',
-                         fg=pwgui.Color.DARK_GREY_COLOR)
-        label.grid(row=0, column=0, sticky='news', padx=(20, 5), pady=10)
-
         # Body section
         bodyFrame = tk.Frame(self, bg='white')
-        bodyFrame.columnconfigure(0, weight=1)
-        bodyFrame.rowconfigure(0, weight=1)
-        bodyFrame.grid(row=1, column=0, sticky='news')
+        bodyFrame.columnconfigure(0, minsize=120)
+        bodyFrame.columnconfigure(1, minsize=120, weight=1)
+        bodyFrame.grid(row=0, column=0, sticky='news')
         self._fillContent(bodyFrame)
 
         # Add the create project button
@@ -151,7 +139,7 @@ class BoxWizardView(tk.Frame):
         btn = HotButton(btnFrame, text=START_BUTTON,
                         font=self.bigFontBold,
                         command=self._onAction)
-        btn.grid(row=0, column=1, sticky='ne', padx=20, pady=10)
+        btn.grid(row=0, column=1, sticky='ne', padx=10, pady=10)
 
         # Add the Import project button
         btn = Button(btnFrame, Message.LABEL_BUTTON_CANCEL,
@@ -160,31 +148,22 @@ class BoxWizardView(tk.Frame):
         btn.grid(row=0, column=0, sticky='ne', pady=10)
 
         btnFrame.columnconfigure(0, weight=1)
-        btnFrame.grid(row=2, column=0, sticky='news')
+        btnFrame.grid(row=1, column=0, sticky='news')
 
         self.columnconfigure(0, weight=1)
 
     def _fillContent(self, frame):
-        # General parameters
-        gpFrame = tk.LabelFrame(frame, text=' General ', bg='white',  font=self.bigFontBold)
-        gpFrame.grid(row=0, column=0, sticky='news', padx=20,  pady=10)
-        gpFrame.columnconfigure(0, minsize=120)
-        gpFrame.columnconfigure(1, minsize=120, weight=1)
-        # Acquisition parameters
-        apFrame = tk.LabelFrame(frame, text=' Acquisition values ', bg='white', font=self.bigFontBold)
-        apFrame.grid(row=1, column=0, sticky='news', padx=20, pady=10)
-        apFrame.columnconfigure(0, minsize=120)
-        apFrame.columnconfigure(1, minsize=120, weight=1)
-        # Data
         self._templateContent, self._templateId = getTemplateSplit(self.template)
-        self._addGeneralFields(gpFrame)
-        self._addFieldsFromTemplate(apFrame)
+        # Add project name
+        self._addPair(PROJECT_NAME, 1, frame,
+                      value=self._templateId + '-' + datetime.now().strftime("%y%m%d-%H%M%S"),
+                      pady=(10, 30))
+        # Add template params
+        self._addFieldsFromTemplate(frame)
 
-    def _addPair(self, text, r, lf, widget='entry', traceCallback=None,
-                 mouseBind=False, value=None):
-        label = tk.Label(lf, text=text, bg='white',
-                         font=self.bigFont)
-        label.grid(row=r, column=0, padx=(10, 5), pady=2, sticky='nes')
+    def _addPair(self, text, r, lf, widget='entry', traceCallback=None,  mouseBind=False, value=None, pady=2):
+        label = tk.Label(lf, text=text, bg='white', font=self.bigFont)
+        label.grid(row=r, column=0, padx=(10, 5), pady=pady, sticky='nes')
 
         if not widget:
             return
@@ -206,7 +185,7 @@ class BoxWizardView(tk.Frame):
             widget = tk.Label(lf, font=self.bigFont, textvariable=var)
 
         self.vars[text] = var
-        widget.grid(row=r, column=1, sticky='news', padx=(5, 10), pady=2)
+        widget.grid(row=r, column=1, sticky='news', padx=(5, 10), pady=pady)
 
     def _addGeneralFields(self, labelFrame):
         self._addPair(PROJECT_NAME, 1, labelFrame,
@@ -215,7 +194,7 @@ class BoxWizardView(tk.Frame):
     def _addFieldsFromTemplate(self, labelFrame):
         self._fields = getFields(self._templateContent)
 
-        row = 2
+        row = 3
         for field in self._fields.values():
             self._addPair(field.getTitle(), row, labelFrame, value=field.getValue())
             row += 1
@@ -262,10 +241,6 @@ class BoxWizardView(tk.Frame):
 
         scipion = SCIPION_EP
         scriptsPath = pw.join('project', 'scripts')
-
-        # Download the required data
-        # pwutils.runCommand(scipion +
-        #                     " testdata --download jmbFalconMovies")
 
         # Create the project
         createProjectScript = os.path.join(scriptsPath, 'create.py')

--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -430,15 +430,16 @@ def getTemplate(root):
     templateFolder = getExternalJsonTemplates()
     customTemplates = len(sys.argv) > 1
     tempList = TemplateList()
+    tempId = ""
     if customTemplates:
-        atributes = {}
+        attributes = {}
         if os.path.isfile(sys.argv[1]):
             t = Template("custom template", sys.argv[1])
             tempList.addTemplate(t)
         else:
             tempId = sys.argv[1]
         for nameAttr, valAttr in (attr.split('=') for attr in sys.argv[2:]):
-            atributes[nameAttr] = valAttr
+            attributes[nameAttr] = valAttr
 
     if len(tempList.templates) == 0:
         # Check if other plugins have json.templates

--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -467,7 +467,7 @@ def getTemplate(root):
     lenTemplates = len(templates)
     if lenTemplates:
         if lenTemplates == 1:
-            chosen = templates[0].templateDir
+            chosen = templates[0]
         else:
             provider = pwgui.tree.ListTreeProviderTemplate(templates)
             dlg = dialog.ListDialog(root, "Workflow templates", provider,
@@ -475,16 +475,11 @@ def getTemplate(root):
 
             if dlg.result == dialog.RESULT_CANCEL:
                 sys.exit()
-            chosen = dlg.values[0].templatePath
-
-        if not customTemplates:
-            chosen = os.path.join(templateFolder, chosen)
+            chosen = dlg.values[0]
 
         print("Template to use: %s" % chosen)
-        with open(chosen, 'r') as myfile:
-            template = myfile.read()
         # Replace environment variables
-        return template % os.environ
+        return chosen.content % os.environ
 
     else:
         raise Exception("No valid file found (*.json.template).\n"
@@ -497,6 +492,7 @@ def getTemplate(root):
 def main():
     wizWindow = BoxWizardWindow()
     wizWindow.show()
+
 
 if __name__ == "__main__":
     main()

--- a/scipion/scripts/kickoff.py
+++ b/scipion/scripts/kickoff.py
@@ -150,32 +150,23 @@ class BoxWizardView(tk.Frame):
         self.rowconfigure(1, weight=1)
 
     def _fillContent(self, frame):
-        labelFrame = tk.LabelFrame(frame, text=' General ', bg='white',
-                                   font=self.bigFontBold)
-        labelFrame.grid(row=0, column=0, sticky='nw', padx=20)
-
-        self._addPair(PROJECT_NAME, 1, labelFrame, value=PROJECT_TEMPLATE)
-        self._addPair(MESSAGE, 4, labelFrame, widget='label')
-
+        # General parameters
+        labelFrame = tk.LabelFrame(frame, text=' General ', bg='white',  font=self.bigFontBold)
+        labelFrame.grid(row=0, column=0, sticky='news', padx=20,  pady=10)
         labelFrame.columnconfigure(0, weight=1)
         labelFrame.columnconfigure(0, minsize=120)
-        labelFrame.columnconfigure(1, weight=1)
-
-        labelFrame2 = tk.LabelFrame(frame, text=' Acquisition values ', bg='white',
-                                    font=self.bigFontBold)
-
-        labelFrame2.grid(row=1, column=0, sticky='nw', padx=20, pady=10)
+        self._addPair(PROJECT_NAME, 1, labelFrame, value=PROJECT_TEMPLATE)
+        # Acquisition parameters
+        labelFrame2 = tk.LabelFrame(frame, text=' Acquisition values ', bg='white', font=self.bigFontBold)
+        labelFrame2.grid(row=1, column=0, sticky='news', padx=20, pady=10)
         labelFrame2.columnconfigure(0, minsize=120)
-
-        self.addFieldsFromTemplate(labelFrame2)
-
-        frame.columnconfigure(0, weight=1)
+        self.addFieldsFromTemplate(labelFrame, labelFrame2)
 
     def _addPair(self, text, r, lf, widget='entry', traceCallback=None,
                  mouseBind=False, value=None):
         label = tk.Label(lf, text=text, bg='white',
                          font=self.bigFont)
-        label.grid(row=r, column=0, padx=(10, 5), pady=2, sticky='ne')
+        label.grid(row=r, column=0, padx=(10, 5), pady=2, sticky='news')
 
         if not widget:
             return
@@ -197,7 +188,7 @@ class BoxWizardView(tk.Frame):
             widget = tk.Label(lf, font=self.bigFont, textvariable=var)
 
         self.vars[text] = var
-        widget.grid(row=r, column=1, sticky='nw', padx=(5, 10), pady=2)
+        widget.grid(row=r, column=1, sticky='news', padx=(5, 10), pady=2)
 
     def _addCheckPair(self, label, r, lf, col=1):
 
@@ -207,12 +198,12 @@ class BoxWizardView(tk.Frame):
                             variable=var)
         self.vars[label] = var
         self.checkvars.append(label)
-        cb.grid(row=r, column=col, padx=5, sticky='nw')
+        cb.grid(row=r, column=col, padx=5, sticky='news')
 
-    def addFieldsFromTemplate(self, labelFrame2):
+    def addFieldsFromTemplate(self, labelFrame1, labelFrame2):
 
-        self._template = getTemplateSplit(self.root)
-
+        self._template, tId = getTemplateSplit(self.root)
+        self._addPair(PROJECT_NAME, 1, labelFrame1, value=tId + '-' + datetime.now().strftime("%y%m%d-%H%M%S"))
         self._fields = getFields(self._template)
 
         row = 2
@@ -329,7 +320,7 @@ class FormField(object):
         return validate(self._value, self._type)
 
 
-class TemplateList():
+class TemplateList:
     def __init__(self, templates=[]):
         self.templates = templates
 
@@ -424,10 +415,10 @@ def replaceFields(fields, template):
 
 def getTemplateSplit(root):
     # Get the fields definition from the template
-    templateStr = getTemplate(root)
+    templateStr, tId = getTemplate(root)
 
     # Split the template by the field separator
-    return templateStr.split(FIELD_SEP)
+    return templateStr.split(FIELD_SEP), tId
 
 
 def getTemplate(root):
@@ -479,7 +470,7 @@ def getTemplate(root):
 
         print("Template to use: %s" % chosen)
         # Replace environment variables
-        return chosen.content % os.environ
+        return chosen.content % os.environ, chosen.getObjId()
 
     else:
         raise Exception("No valid file found (*.json.template).\n"
@@ -490,6 +481,8 @@ def getTemplate(root):
 
 
 def main():
+
+
     wizWindow = BoxWizardWindow()
     wizWindow.show()
 


### PR DESCRIPTION
Kickoff adapted to let the json.template file be read when the Template object is created instead of at the end of getTemplate, in order to know the description of each template (if there's a description) before generating the window with the list of templates, so the descriptions can be displayed.
UPDATE:
Kickoff refactored.
Form window layout updated.