### PR TITLE
Gencleanconfig

### DIFF
--- a/scipion/__main__.py
+++ b/scipion/__main__.py
@@ -131,15 +131,6 @@ class Vars:
 
     # Installation paths
     SCIPION_HOME = scipionHome
-    # TODO: This, hopefully is a temporary way to load Xmipp binding and it's libraries
-    SCIPION_LIBS = join(SCIPION_HOME, "software", "lib")
-    os.makedirs(SCIPION_LIBS, exist_ok=True)
-
-    SCIPION_BINDINGS = join(SCIPION_HOME, "software", "bindings")
-    os.makedirs(SCIPION_BINDINGS, exist_ok=True)
-
-    # Add bindings to sys.path
-    sys.path.append(SCIPION_BINDINGS)
 
     # Some pw_*.py scripts under 'apps' folder change the current working
     # directory to the SCIPION_HOME, so let's keep the current working
@@ -170,18 +161,17 @@ class Vars:
 try:
     VARS = dict()
 
-    # Prepare PYTHON PATH
-    ignorePythonPath = os.environ.get('SCIPION_IGNORE_PYTHONPATH', False)
-    PYTHONPATH_LIST = [
-                       os.environ.get('PYTHONPATH', '') if not ignorePythonPath else "",
-                       Vars.SCIPION_BINDINGS,
-                       ]
+    # Load variables from Vars class into VARS dict
 
     if 'SCIPION_NOGUI' in os.environ:
-        PYTHONPATH_LIST.insert(0, join(pyworkflow.Config.getPyworkflowPath(), 'gui', 'no-tkinter'))
+        # This cannot work since pyworkflow is not imported and can not be imported here
+        # Due to a wrong/early initialisation of the config
+        #PYTHONPATH_LIST.insert(0, join(pyworkflow.Config.getPyworkflowPath(), 'gui', 'no-tkinter'))
+        print("SCIPION_NOGUI variable not implemented for this version. Please contact us if you need this.")
 
-    # Load variables from Vars class into VARS dict
-    PYTHONPATH = os.pathsep.join(PYTHONPATH_LIST)
+    # Prepare PYTHON PATH
+    ignorePythonPath = os.environ.get('SCIPION_IGNORE_PYTHONPATH', False)
+    PYTHONPATH = os.environ.get('PYTHONPATH', '') if not ignorePythonPath else ''
 
     # Load VARS dictionary, all items here will go to the environment
     VARS['PYTHONPATH'] = PYTHONPATH
@@ -206,11 +196,8 @@ except Exception as e:
                          'try again.\n' % Vars.SCIPION_CONFIG)
         sys.exit(1)
 
-
-#
 # Auxiliary functions to run commands in our environment, one of our
 # scripts, or one of our "apps"
-#
 def runCmd(cmd, args=''):
     """ Runs ANY command with its arguments"""
     if isinstance(args, list):

--- a/scipion/__main__.py
+++ b/scipion/__main__.py
@@ -169,12 +169,8 @@ try:
         #PYTHONPATH_LIST.insert(0, join(pyworkflow.Config.getPyworkflowPath(), 'gui', 'no-tkinter'))
         print("SCIPION_NOGUI variable not implemented for this version. Please contact us if you need this.")
 
-    # Prepare PYTHON PATH
-    ignorePythonPath = os.environ.get('SCIPION_IGNORE_PYTHONPATH', False)
-    PYTHONPATH = os.environ.get('PYTHONPATH', '') if not ignorePythonPath else ''
 
     # Load VARS dictionary, all items here will go to the environment
-    VARS['PYTHONPATH'] = PYTHONPATH
     VARS['SCIPION_DOMAIN'] = Vars.SCIPION_DOMAIN
     VARS['SCIPION_CONFIG'] = Vars.SCIPION_CONFIG
     VARS['SCIPION_LOCAL_CONFIG'] = Vars.SCIPION_LOCAL_CONFIG
@@ -316,6 +312,11 @@ def main():
 
     elif mode == MODE_ENV:
         # Print all the environment variables needed to run scipion.
+        from pyworkflow.plugin import Plugin
+
+        # Trigger plugin's variable definition
+        pyworkflow.Config.getDomain().getPlugins()
+        VARS.update(pyworkflow.plugin.Plugin.getVars())
         for key in sorted(VARS):
             sys.stdout.write('export %s="%s"\n' % (key, VARS[key]))
 

--- a/scipion/scripts/config.py
+++ b/scipion/scripts/config.py
@@ -29,8 +29,7 @@ import os
 from os.path import join, exists, basename
 import time
 import optparse
-# We use optparse instead of argparse because we want this script to
-# be compatible with python >= 2.3
+from pathlib import Path
 import collections
 from shutil import copyfile
 
@@ -209,8 +208,14 @@ def addVariablesToSection(cf, section, vars):
         if varValue.startswith(pwem.Config.EM_ROOT):
             varValue = varValue.replace(pwem.Config.EM_ROOT, "%(EM_ROOT)s")
 
-        if varValue.startswith(pw.Config.SCIPION_HOME):
+        # If value contains SCIPION_HOME and is not scipion home
+        if varValue.startswith(pw.Config.SCIPION_HOME) and varValue != pw.Config.SCIPION_HOME:
             varValue = varValue.replace(pwem.Config.SCIPION_HOME, "%(SCIPION_HOME)s")
+
+        # Replace HOME paths with ~
+        home = str(Path.home())
+        if varValue.startswith(home):
+            varValue = varValue.replace(home, "~")
 
         return varValue
 


### PR DESCRIPTION
This goes with 2 others PR in pw and scipion--em

Addresses some cases where the config wasn't working: having relative paths or ~ in the variables.

It also generates a cleaner config file, relating variables to SCIPION_HOME and EM_ROOT.