### PR TITLE
Fix scipion main

### DIFF
--- a/scipion/__main__.py
+++ b/scipion/__main__.py
@@ -106,7 +106,7 @@ while len(sys.argv) > 2 and sys.argv[1].startswith('--'):
         scipionLocalConfig = scipionConfig = os.path.abspath(os.path.expanduser(value))
 
         # Verify existence if not config
-        if sys.argv[1] != MODE_CONFIG and not exists(scipionConfig):
+        if not exists(scipionConfig):
             # Here we can react differently,instead of exiting, may be continuing warning about
             # the missing config file?
             sys.exit('Config file missing: %s' % scipionConfig)


### PR DESCRIPTION
When a config file is introduced it fails because sys.argv has been removed before. This is due to the fact that variable 'value' has been set using pop function in sys.argv, so the element is removed from the list and at the end it only has 1 element, and because of that sys.argv[1] fails.

I also think that the if statement doesn't need to check the sys.argv because all the cases (I've tested calling Scipion with config, no config and non-existing config file) and they all work correctly this way.