### PR TITLE
Printing config vars associets with a plugin

### DIFF
--- a/scipion/scripts/config.py
+++ b/scipion/scripts/config.py
@@ -76,7 +76,7 @@ def main(args=None):
              "TO BE DEPRECATED, use unattended param instead")
     add('--unattended', action='store_true',
         help="Scipion will skipping questions")
-    add('-p', help='Prints the config variables associated to that plugin')
+    add('-p', help='Prints the config variables associated to plugin P')
 
     add(COMPARE_PARAM, action='store_true',
         help="Check that the configurations seems reasonably well set up.")
@@ -90,15 +90,22 @@ def main(args=None):
 
     if options.p:
         import pyworkflow.utils as pwutils
-        plugin = pwutils.Config.getDomain().importFromPlugin(options.p,
-                                                             'Plugin')
+        pluginName = options.p
+        plugin = (pwutils.Config.getDomain().
+                  importFromPlugin(pluginName, 'Plugin'))
+
         if plugin is not None:
             plugin._defineVariables()
 
-            print("Variables defined by plugin '%s':\n" % options.p)
-
+            print("Variables defined by plugin '%s':\n" % pluginName)
             for k, v in plugin._vars.items():
                 print("%s = %s" % (k, v))
+            print("\nThese variables can be added/edited in '%s'"
+                  % os.environ[SCIPION_CONFIG])
+        else:
+            print("No plugin found with name '%s'. Module name is expected,\n"
+                  "i.e. 'scipion3 config -p xmipp3' shows the config variables "
+                  "defined in 'scipion-em-xmipp' plugin." % pluginName)
 
         sys.exit(0)
 

--- a/scipion/scripts/config.py
+++ b/scipion/scripts/config.py
@@ -76,6 +76,7 @@ def main(args=None):
              "TO BE DEPRECATED, use unattended param instead")
     add('--unattended', action='store_true',
         help="Scipion will skipping questions")
+    add('-p', help='Prints the config variables associated to that plugin')
 
     add(COMPARE_PARAM, action='store_true',
         help="Check that the configurations seems reasonably well set up.")
@@ -86,6 +87,20 @@ def main(args=None):
         sys.exit(parser.format_help())
 
     unattended = options.notify or options.unattended
+
+    if options.p:
+        import pyworkflow.utils as pwutils
+        plugin = pwutils.Config.getDomain().importFromPlugin(options.p,
+                                                             'Plugin')
+        if plugin is not None:
+            plugin._defineVariables()
+
+            print("Variables defined by plugin '%s':\n" % options.p)
+
+            for k, v in plugin._vars.items():
+                print("%s = %s" % (k, v))
+
+        sys.exit(0)
 
     try:
         # where templates are


### PR DESCRIPTION
Ussage: 

```
$ scipion3 config -p motioncorr

Scipion v3.0 () devel

Variables defined by plugin 'motioncorr':

MOTIONCOR2_BIN = MotionCor2_v1.3.1-Cuda92
MOTIONCOR2_HOME = /home/user/scipion3/software/em/motioncor2-1.3.1

These variables can be added/edited in '/home/user/scipion3/config/scipion.conf'
```

Drawback: module name is expected instead of plugin name ('motioncorr' instead of 'scipion-em-motioncorr') and module name is transparent for users...