### PR TITLE
do not change cwd in any plugin mode.

### DIFF
--- a/scipion/__main__.py
+++ b/scipion/__main__.py
@@ -280,8 +280,6 @@ def main():
     #     runScript('scipion install %s' % ' '.join(sys.argv[2:]))
 
     elif mode in PLUGIN_MODES:
-        os.chdir(Vars.SCIPION_HOME)
-
         os.environ.update(VARS)
         from scipion.install import installPluginMethods
         installPluginMethods()

--- a/scipion/install/install_plugin.py
+++ b/scipion/install/install_plugin.py
@@ -199,7 +199,7 @@ def installPluginMethods():
                 pluginSrc = p[0]
                 pluginName = ""
                 if os.path.exists(pluginSrc):
-                    pluginName = os.path.basename(pluginSrc.rstrip('/'))
+                    pluginName = os.path.basename(os.path.abspath(pluginSrc).rstrip('/'))
                 else:  # we assume it is a git url
                     m = re.match('https://github.com/(.*)/(.*).git', pluginSrc)
                     if m:


### PR DESCRIPTION
This PR allows plugins to be installed in devel mode without the need of passing an absolute path. It should wor also using . or ..

This should prevent: https://github.com/scipion-em/scipion-app/issues/70
Closes #70 