### PR TITLE
NameError: name 'logging' is not defined

### DIFF
--- a/scipion/install/plugin_manager.py
+++ b/scipion/install/plugin_manager.py
@@ -24,6 +24,7 @@
 # *
 # **************************************************************************
 from logging.handlers import RotatingFileHandler
+import logging
 from tkinter import *
 import threading
 


### PR DESCRIPTION
when I open scipion and select from the menu Others the option Plugins the following error appears:

=====
 /home/roberto/scipion3/scipion3
Scipion v3.0.11 - Eugenius
/home/roberto/miniconda/envs/scipion3/lib/python3.8/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
Traceback (most recent call last):
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 1150, in <module>
    main()
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 1146, in main
    PluginManager("Plugin manager", None).show()
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 1142, in __init__
    PluginBrowser(self.root, **kwargs)
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 350, in __init__
    self._fillPluginManagerGui(parentFrame)
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 406, in _fillPluginManagerGui
    self._fillRightBottomOutputLogPanel(consoleTab)
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 666, in _fillRightBottomOutputLogPanel
    self.plug_log = getRotatingFileLogger("plugins_stdout", self.file_log_path)
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 1126, in getRotatingFileLogger
    logger = logging.getLogger(name)
NameError: name 'logging' is not defined
Exception in thread loading_plugin:
Traceback (most recent call last):
  File "/home/roberto/miniconda/envs/scipion3/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/roberto/miniconda/envs/scipion3/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/roberto/scipion3/scipion-app/scipion/install/plugin_manager.py", line 960, in loadPlugins
    countPlugin = self.progressbar['value']
  File "/home/roberto/miniconda/envs/scipion3/lib/python3.8/tkinter/__init__.py", line 1652, in cget
    return self.tk.call(self._w, 'cget', '-' + key)
RuntimeError: main thread is not in main loop
=====

My guess is that logging needs to be imported.