### PR TITLE
Install helper: Python requirements.txt file not expected by default

### DIFF
--- a/scipion/install/funcs.py
+++ b/scipion/install/funcs.py
@@ -1086,7 +1086,7 @@ class InstallHelper():
 
         return self
     
-    def getCondaEnvCommand(self, binaryName: str=None, binaryPath: str=None, binaryVersion: str=None, pythonVersion: str=None, requirementsFile: bool=True,
+    def getCondaEnvCommand(self, binaryName: str=None, binaryPath: str=None, binaryVersion: str=None, pythonVersion: str=None, requirementsFile: bool=False,
                            requirementFileName: str='requirements.txt', requirementList: List[str]=[], extraCommands: List[str]=[], targetName: str=None):
         """
         ### This function creates the command string for creating a Conda enviroment and installing required dependencies for a given binary inside a package.


### PR DESCRIPTION
Use of a Python requirements.txt file by default while creating a Conda enviroment is now switched off in the install helper.

Found out most enviroments don't actually need that, so it's less of a hassle if you need to use the param with True to use it rather than not needing it and having to find out you have to switch it off.