### PR TITLE
 - Update message is green now

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
-
+V3.2.0
+ - Update message is green now
+ - SCIPION_DONT_INSTALL_BINARIES is used in the plugin manager to initialize "Skip binaries" check box
 v3.1.0
 users:
  - Fixing an error related with the Plugin Manager when clicking the plugin treeview

--- a/scipion/install/plugin_manager.py
+++ b/scipion/install/plugin_manager.py
@@ -27,12 +27,11 @@ from logging.handlers import RotatingFileHandler
 from tkinter import *
 import threading
 
-from pyworkflow import Config
 from pyworkflow.gui.project import ProjectManagerWindow
 from pyworkflow.project import MenuConfig
 from pyworkflow.gui import *
 import pyworkflow.gui.dialog as pwgui
-from scipion.install.plugin_funcs import PluginRepository, PluginInfo, NULL_VERSION
+from scipion.install.plugin_funcs import PluginRepository, PluginInfo, NULL_VERSION, installBinsDefault
 
 from pyworkflow.utils.properties import *
 from pyworkflow.utils import redStr, makeFilePath
@@ -434,7 +433,7 @@ class PluginBrowser(tk.Frame):
         # Add option to cancel binaries installation
         self._col += 1
         self.skipBinaries = tk.BooleanVar()
-        self.skipBinaries.set(False)
+        self.skipBinaries.set(not installBinsDefault())
         installBinsEntry = tk.Checkbutton(frame, variable=self.skipBinaries,
                                           font=getDefaultFont(), text="Skip binaries")
         installBinsEntry.grid(row=0, column=self._col, sticky='ew', padx=5)

--- a/scipion/install/update_manager.py
+++ b/scipion/install/update_manager.py
@@ -92,7 +92,7 @@ class UpdateManager:
             if needToUpdate:
                 outdatedPackages.append((package[0], version))
                 print(
-                    redStr('The package %s is out of date. Your version is %s, '
+                    greenStr('The package %s is out of date. Your version is %s, '
                            'the latest is %s.' % (package[0], package[1],
                                                   version)))
             elif printAll:


### PR DESCRIPTION
 - SCIPION_DONT_INSTALL_BINARIES is used in the plugin manager to initialize "Skip binaries" check box