### PR TITLE
- Exist code is not masked when running xmipp, relion etc commands

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+V3.3.0
+developers:
+ - Exist code is not masked when running xmipp, relion etc commands
+ - CommandDef and CondaCommandDef assist in the definition of commands for the binaries
 V3.2.0
  - Update message is green now
  - SCIPION_DONT_INSTALL_BINARIES is used in the plugin manager to initialize "Skip binaries" check box

--- a/scipion/__main__.py
+++ b/scipion/__main__.py
@@ -30,6 +30,7 @@
 """
 Main entry point to scipion. It launches the gui, tests, etc.
 """
+import subprocess
 import sys
 import os
 from os.path import join, exists, expanduser, expandvars
@@ -104,10 +105,9 @@ def runCmd(cmd, args=''):
     cmd = '%s %s' % (cmd, args)
 
     os.environ.update(VARS)
-    # sys.stdout.write(">>>>> %s\n" % cmd)
-    result = os.system(cmd)
-    if not -256 < result < 256:
-        result = 1  # because if not, 256 is confused with 0 !
+    # result = os.system(cmd)
+    # Replacement of os.system with subprocess.call(cmd, shell=True)
+    result = subprocess.call(cmd, shell=True)
     sys.exit(result)
 
 

--- a/scipion/tests/installation.py
+++ b/scipion/tests/installation.py
@@ -1,0 +1,24 @@
+import unittest
+from scipion.install.funcs import CommandDef, CondaCommandDef
+
+class TestCommands(unittest.TestCase):
+    def test_command_class(self):
+
+        myCmd = CommandDef("ls -l", "lolo")\
+            .append("cd ..", ["one", "two"])\
+            .append("cd .", sep="?")
+
+        self.assertEqual(myCmd.getCommands()[0][0], "ls -l && cd .. ? cd .")
+        self.assertEqual(myCmd.getCommands()[0][1], ["lolo", "one", "two"])
+
+        cmds = CondaCommandDef("modelangelo-3.0")
+        cmds.create('python=3.9').activate().cd('model-angelo')\
+            .pipInstall('-r requirements.txt')\
+            .condaInstall('-y torchvision torchaudio cudatoolkit=11.3 -c pytorch')\
+            .pipInstall('-e .').touch('../env-installed.txt')
+
+        print(cmds.getCommands())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
 - CommandDef and CondaCommandDef assist in the definition of commands for the binaries
 
Inspired by @MartinSalinas98 approach I've created some basic classes to deal with the creation of the command list when defining binaries.